### PR TITLE
feat: add da input arg and connect celestia da package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV GOPATH /usr/local/go
 ENV PATH $GOPATH/bin:$PATH
 
 # Install Rollkit dependencies
-RUN curl -sSL https://rollkit.dev/install.sh | sh -s v0.13.5
+RUN curl -sSL https://rollkit.dev/install.sh | sh -s v0.13.7
 
 # Install GM rollup
 RUN bash -c "$(curl -sSL https://rollkit.dev/install-gm-rollup.sh)"

--- a/main.star
+++ b/main.star
@@ -30,7 +30,7 @@ def run(
         # TODO: add inputs to target mocha
         plan.print("Using celestia for DA")
         da_node = import_module(
-            "github.com/rollkit/kurtosis-celestia-da-node/main.star"
+            "github.com/rollkit/kurtosis-celestia-da-node/main.star@v0.1.0"
         )
         da_rpc_address, da_auth_token, da_wallet_address, da_height = da_node.run(
             plan,

--- a/main.star
+++ b/main.star
@@ -1,6 +1,4 @@
 # This Kurtosis package spins up a minimal GM rollup that connects to a DA node
-#
-# NOTE: currently this is only connecting to a local DA node
 
 # DA Types
 celestia = "celestia"
@@ -8,51 +6,57 @@ avail = "avail"
 local_da = "local-da"
 
 
-def run(plan, da=local_da):
+def run(
+    plan,
+    da=local_da,
+    da_namespace="00000000000000000000000000000000000000000008e5f679bf7116cb",
+):
     # Define vars
-    da_address = None
+    da_rpc_address = None
     da_auth_token = None
+    da_wallet_address = None
+    da_height = None
 
     # Start up the DA node
     plan.print("Starting up GM rollup with DA: {0}".format(da))
     if da == local_da:
         plan.print("Using local-da")
         da_node = import_module("github.com/rollkit/local-da/main.star@v0.3.1")
-        da_address = da_node.run(
+        da_rpc_address = da_node.run(
             plan,
         )
     elif da == celestia:
+        # Uses arabica by default
+        # TODO: add inputs to target mocha
         plan.print("Using celestia for DA")
-        da_node = import_module("github.com/MSevey/celestia-da-node-package/main.star")
-        da_address, da_auth_token = da_node.run(
+        da_node = import_module(
+            "github.com/rollkit/kurtosis-celestia-da-node/main.star"
+        )
+        da_rpc_address, da_auth_token, da_wallet_address, da_height = da_node.run(
             plan,
         )
     else:
         fail("Unknown DA: {0}".format(da))
 
-    plan.print("connecting to da layer via {0}".format(da_address))
+    plan.print("connecting to da layer via {0}".format(da_rpc_address))
     #####
     # GM
     #####
 
     plan.print("Adding GM service")
     plan.print("NOTE: This can take a few minutes to start up...")
-    gm_start_cmd = []
-    if da == celestia:
-        gm_start_cmd = rollkitCMD(
-            da,
-            da_auth_token=da_auth_token,
-            da_namespace="00000000000000000000000000000000000000000008e5f679bf7116cb",  # Make an input, people can set this to whatever they want
-            da_start_height=2535482,  # Make an input, people can pull this from a block explorer
-        )
-    elif da == avail:
-        fail("Avail DA is not yet supported")
-    elif da == local_da:
-        gm_start_cmd = rollkitCMD(da, da_address)
-    else:
-        fail("Unknown DA: {0}".format(da))
 
+    # Generate start command
+    gm_start_cmd = rollkitCMD(
+        da,
+        da_address=da_rpc_address,
+        da_auth_token=da_auth_token,
+        da_namespace=da_namespace,
+        da_start_height=da_height,
+    )
     plan.print("GM start command: {0}".format(gm_start_cmd))
+
+    # Build GM Service Spec
     gm_port_number = 26657
     gm_port_spec = PortSpec(
         number=gm_port_number, transport_protocol="TCP", application_protocol="http"
@@ -123,10 +127,11 @@ def rollkitCMD(
             "rollkit",
             "start",
             "--rollkit.aggregator",
+            "--rollkit.da_address {0}".format(da_address),
             "--rollkit.da_auth_token {0}".format(da_auth_token),
             "--rollkit.da_namespace {0}".format(da_namespace),
             "--rollkit.da_start_height {0}".format(da_start_height),
-            "--minimum-gas-price=0.025stake",
+            "--minimum-gas-prices=0.025stake",
         ]
     elif da == avail:
         fail("Avail DA is not yet supported")


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->

This PR extends the kurtosis package to target multiple DA layers and brings in celestia as an option. 

User can now use this package to run the GM tutorial with local da by default or target the celestia DA. 
This was tested with the defaults of the celestia da package which targets arabica. 

Currently this is block by the celestia DA package being blocked on a dockerfile fix in celestia node. 
